### PR TITLE
LocationCloseAction - Encapsulate logic for location back.

### DIFF
--- a/src/toolbar/left-action.component.html
+++ b/src/toolbar/left-action.component.html
@@ -1,4 +1,4 @@
-﻿<button *ngIf="leftAction" mat-icon-button [title]="leftAction.text" (click)="leftAction.action()">
+﻿<button #btn *ngIf="leftAction" mat-icon-button [title]="leftAction.text">
     <mat-icon>{{leftAction.iconClasses}}</mat-icon>
     <span class="sr-only">{{leftAction.text}}</span>
 </button>

--- a/src/toolbar/left-action.component.ts
+++ b/src/toolbar/left-action.component.ts
@@ -1,19 +1,62 @@
 ﻿import {
+    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
+    ElementRef,
     Input,
-}                       from '@angular/core';
+    OnDestroy,
+    QueryList,
+    ViewChildren,
+}                                   from '@angular/core';
+import {
+    Subject,
+    fromEvent,
+}                                   from 'rxjs';
+import {
+    debounceTime,
+    filter,
+    mergeMap,
+    takeUntil,
+}                                   from 'rxjs/operators';
 
-import { LeftAction }   from './left-action.model';
+import {
+    LeftAction,
+    LocationBackAction,
+    LocationCloseAction,
+}                                   from './left-action.model';
 
 @Component({
     selector: 'cf-toolbar-left-action',
     templateUrl: 'left-action.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LeftActionComponent {
-    @Input() leftAction: LeftAction;
+export class LeftActionComponent implements AfterViewInit, OnDestroy {
+    @Input() leftAction: LeftAction = null;
 
-    constructor() {
+    @ViewChildren('btn', { read: ElementRef }) viewChildren: QueryList<ElementRef>;
+
+    private _destroy$: Subject<void> = new Subject<void>();
+
+    constructor() { }
+
+    ngAfterViewInit(): void {
+        this.viewChildren.changes
+            .pipe(
+                filter(buttons => buttons.length > 0),
+                mergeMap(buttons => this.leftAction instanceof LocationCloseAction ||
+                    this.leftAction instanceof LocationBackAction ?
+                    fromEvent(buttons.first.nativeElement, 'click').pipe(debounceTime(500)) :
+                    fromEvent(buttons.first.nativeElement, 'click')),
+                takeUntil(this._destroy$))
+            .subscribe(() => this._clickAction());
+    }
+
+    ngOnDestroy(): void {
+        this._destroy$.next();
+        this._destroy$.complete();
+    }
+
+    private _clickAction(): void {
+        this.leftAction.action();
     }
 }

--- a/src/toolbar/left-action.model.ts
+++ b/src/toolbar/left-action.model.ts
@@ -1,4 +1,6 @@
-﻿import { ToolbarService }   from './toolbar.service';
+﻿import { Location }         from '@angular/common';
+
+import { ToolbarService }   from './toolbar.service';
 
 export class LeftAction {
     constructor(
@@ -17,6 +19,18 @@ export class BackAction extends LeftAction {
 export class CloseAction extends LeftAction {
     constructor(action: () => void) {
         super('Close', 'close', action);
+    }
+}
+
+export class LocationCloseAction extends CloseAction {
+    constructor(private _location: Location) {
+        super(() => this._location.back());
+    }
+}
+
+export class LocationBackAction extends BackAction {
+    constructor(private _location: Location) {
+        super(() => this._location.back());
     }
 }
 


### PR DESCRIPTION
Used debounce on observable to prevent consumers known to be using the newly created LocationBackAction from accidentally going back too far in history.